### PR TITLE
allow unit test runs on forks

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -30,6 +30,8 @@ jobs:
           pip install -r requirements.txt
       - name: Test with Django unit tests
         env:
-          SECRET_KEY: ${{ secrets.SECRET_KEY }}
+          # For unit tests, secret_key just needs to be populated.
+          # It will only ever access a temporary Django test database.
+          SECRET_KEY: unit-test-fake-secret-key-#5TY90
         run: |
           python manage.py test --debug-mode


### PR DESCRIPTION
Remove reference to secrets.SECRET_KEY in order to be able to run unit tests against PR's made from forks. From the github docs "Secrets are not passed to workflows that are triggered by a pull request from a fork." which is **not** what we want. We need to be able to see if changes by a PR pass basic unit tests before review/merge process can continue.