### PR TITLE
Feature/safe migrations

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: python migrations.py && gunicorn idemia.wsgi --log-file -
+web: python migrations.py && gunicorn transaction_log.wsgi --log-file -

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: python manage.py migrate && gunicorn transaction_log.wsgi --log-file -
+web: python migrations.py && gunicorn idemia.wsgi --log-file -

--- a/manifest.yml
+++ b/manifest.yml
@@ -13,3 +13,4 @@ applications:
     env:
       SECRET_KEY: ((SECRET_KEY))
       DISABLE_COLLECTSTATIC: 1
+      DJANGO_SETTINGS_MODULE: transaction_log.settings

--- a/migrations.py
+++ b/migrations.py
@@ -1,0 +1,19 @@
+"""
+migrations.py implements the 'Migrate Frequently' section of
+https://docs.huihoo.com/cloudfoundry/documentation/devguide/services/migrate-db.html
+"""
+import logging
+import os
+from cfenv import AppEnv
+from django.core.management import execute_from_command_line
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "transaction_log.settings")
+ENV = AppEnv()
+
+
+# Only allow the 0th instance of the application to run the migration scripts on the
+# database. When deploying there will always be at least 1 application instance.
+if ENV.index == 0:
+    logging.warning("Instance index 0 started -- running migrations script")
+    execute_from_command_line(["manage.py", "migrate"])
+    logging.warning("Migrations complete")


### PR DESCRIPTION
Prevent the transaction logging service from attempting to run migrations from multiple application instances when a high-availability deployment includes more than one instance being started.