### PR TITLE
Feature/local psql - Replace sqlite with psql db for local testing

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -14,8 +14,20 @@ on:
       - '**.md'
 
 jobs:
-  test:
+  runner-job:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
@@ -37,5 +49,7 @@ jobs:
           # For unit tests, secret_key just needs to be populated.
           # It will only ever access a temporary Django test database.
           SECRET_KEY: unit-test-fake-secret-key-#5TY90
+          POSTGRES_HOST: postgres
+          POSTGRES_PORT: 5432
         run: |
           python manage.py test --debug-mode

--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ Env:SECRET_KEY=<your-secret-here>
 Note: during development, it may also be helpful to add the `DEBUG` environment
 variable and setting it to the string `True`
 
+Setup a local PSQL database to mirror the cloud.gov database used.
+
+docker run -d --name dev-postgres -e PASSWORD=postgres -v /tmp/transaction-logging-microservice/:/var/lib/postgresql/data -p 5432:5432 postgres
+
 ### Running the application
 After completing [development setup](#development-setup) and
 [environment variable setup](#required-environment-variables) you can run the

--- a/README.md
+++ b/README.md
@@ -75,8 +75,9 @@ Note: during development, it may also be helpful to add the `DEBUG` environment
 variable and setting it to the string `True`
 
 Setup a local PSQL database to mirror the cloud.gov database used.
-
+```
 docker run -d --name dev-postgres -e POSTGRES_PASSWORD=postgres -v /tmp/transaction-logging-microservice/:/var/lib/postgresql/data -p 5432:5432 postgres
+```
 
 ### Running the application
 After completing [development setup](#development-setup) and

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ variable and setting it to the string `True`
 
 Setup a local PSQL database to mirror the cloud.gov database used.
 
-docker run -d --name dev-postgres -e PASSWORD=postgres -v /tmp/transaction-logging-microservice/:/var/lib/postgresql/data -p 5432:5432 postgres
+docker run -d --name dev-postgres -e POSTGRES_PASSWORD=postgres -v /tmp/transaction-logging-microservice/:/var/lib/postgresql/data -p 5432:5432 postgres
 
 ### Running the application
 After completing [development setup](#development-setup) and

--- a/transaction_log/settings.py
+++ b/transaction_log/settings.py
@@ -117,9 +117,14 @@ if VCAP_ENV_VAR in os.environ:
     }
 else:
     # Local development -- use local DB info
+    # See README for setting up postgres container
     DB_DICT = {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": BASE_DIR / "db.sqlite3",
+        "ENGINE": "django.db.backends.postgresql",
+        "NAME": "postgres",
+        "USER": "postgres",
+        "PASSWORD": "postgres",
+        "HOST": "127.0.0.1",
+        "PORT": "5432",
     }
 
 DATABASES = {"default": DB_DICT}


### PR DESCRIPTION
PSQL is used in cloud.gov and must be mirrored in testing environments.